### PR TITLE
inclusion error : Wireless double remote switch (067774)

### DIFF
--- a/devices/legrand.js
+++ b/devices/legrand.js
@@ -146,7 +146,7 @@ module.exports = [
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg', 'genOnOff', 'genLevelCtrl']);
             const endpoint2 = device.getEndpoint(2);
-            await reporting.bind(endpoint2, coordinatorEndpoint, ['genPowerCfg', 'genOnOff', 'genLevelCtrl']);
+            await reporting.bind(endpoint2, coordinatorEndpoint, ['genOnOff', 'genLevelCtrl']);
         },
         endpoint: (device) => {
             return {left: 1, right: 2};


### PR DESCRIPTION
deletion of the creation of the reporting genPowerCfg endpoint2 for the Wireless double remote switch device because it does not exist and the inclusion is not done completely (purple light and not green)

https://github.com/Koenkk/zigbee2mqtt/issues/12355